### PR TITLE
Structured Dramatis Personae

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,3 +1,5 @@
+#let _description-state = state("description-state", ().to-dict() )
+
 #let stage-direction(blocked: true, body) = {
   if blocked {
     align(center, box(width: 70%)[
@@ -13,6 +15,15 @@
   } else {
     text(style: "italic", gray)[#body]
   }
+}
+
+#let descriptions(..roles) = {
+  let all-descriptions = ().to-dict()
+  for role in roles.pos() {
+    let name = role.at("name").replace(" ", sym.space.nobreak)
+    all-descriptions.insert(name, role)
+  }
+  _description-state.update(all-descriptions)
 }
 
 #let to-string(it) = {
@@ -336,15 +347,47 @@
 
   if dramatis-personae {
     context {
-      let roles = query(<tagged_speaker>)
+      let rolenames = query(<tagged_speaker>)
             .map(t => t.value)
             .flatten()
             .dedup()
-      if (roles.len() > 0) {
+      if (rolenames.len() > 0) {
         page(header: none, footer: none)[
           #heading(numbering: none, localization("dramatis-personae-title"))
           \
-          #list(..roles)
+          #{
+            let groups = ().to-dict()
+
+            for rolename in rolenames {
+              let detailed-role = _description-state.get().at(rolename, default:(name:rolename))
+              let group-name = detailed-role.at("group", default: "None")
+              if group-name not in groups {
+                groups.insert(group-name, ())
+              }
+              groups.at(group-name).push(detailed-role)
+            }
+
+            show table.cell.where(x: 1): align.with(center)
+            show table.cell.where(x: 2): align.with(right)
+            show table.cell.where(x: 1): it => emph(text(gray, it))
+
+            for group-name in groups.keys() {
+              align(center, strong(
+                if group-name != "None" {group-name} else {none}
+              ))
+              let cells = ()
+              for role in groups.at(group-name) {
+                cells.push(role.name)
+                cells.push(role.at("desc", default: none))
+                cells.push(role.at("actor", default: none))
+                //cells.push()
+              }
+
+              table(columns:(1fr, 1fr, 1fr), stroke:none,
+                ..cells
+              )
+            }
+          }
         ]
       }
     }

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,4 +1,10 @@
-#import "@preview/stagehand:0.1.0":*
+#import "@preview/stagehand:0.1.1":*
+
+#descriptions(
+  (name:"Alice", group:"Nerds", desc:"A Nerd called Alice", actor:"Andrea"),
+  (name:"Bob", group:"Jocks", desc:"A jock named Boris", actor:"Boris"),
+  (name:"Cedric", group:"Nerds", desc:"Another Nerd", actor:"Celine")
+)
 
 #show: stagehand.with(
   title: "A Template for Theatre",
@@ -39,7 +45,7 @@ I'd rather wear my emotions on the sleeve, and put them right behind my name.
 The command takes an optional parameter: 'blocked'. If 'blocked' is false, it looks like this: #stage-direction(blocked: false)[He gestures around in a surprising lack of parentheses.]
 #speaker[Alice]
 Instead of having to write "\#speaker" and "\#stage-direction" all the time, we can import these names with dedicated aliases:
-#import "@preview/stagehand:0.1.0":stage-direction as d, speaker as s
+#import "@preview/stagehand:0.1.1":stage-direction as d, speaker as s
 #d[Alice uses some magic and imports the command with a new name.]
 #s[Bob]
 We can also define functions for our names, so we don't have to write them out all the time.
@@ -63,3 +69,8 @@ Please fasten your seatbelts.
 #alice() They also show up at the end of the document, in their dedicated list. You can click on them, to go back here.
 #bob() There are many options to play around in the ```typ #show: theatre.with(...)
 ``` block at the start of the page. Almost all of these options are set to their default values, so you can remove them if you want to. #todo[Change some default values]
+== Or is there more?
+#s[Xaver]
+Ich bin auch hier
+#s[Cedric]
+Ich auch.

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stagehand"
-version = "0.1.0"
+version = "0.1.1"
 entrypoint = "lib.typ"
 authors = ["Aaron Prott <https://github.com/aarquelle>"]
 license = "MIT"


### PR DESCRIPTION
Adds more descriptions to the dramatis personae. A role can be associated with a description, an actor and a "group" of roles.

<img width="565" height="262" alt="image" src="https://github.com/user-attachments/assets/acee1205-bf9f-461e-b41e-76eba2ffbd55" />

The names show up in order of appearance within their group.

The details can be configured by calling something like this at the beginning of the document. Only "name" is required, it should be identical to the name used in tags.
```typst
#descriptions(
  (name:"Alice", group:"Nerds", desc:"A Nerd called Alice", actor:"Andrea"),
  (name:"Bob", group:"Jocks", desc:"A jock named Boris", actor:"Boris"),
  (name:"Cedric", group:"Nerds", desc:"Another Nerd", actor:"Celine")
)
```
Only roles that actually show up in the text are shown in the Dramatis Personae. Roles that are not mentioned in the `#descriptions()` call but in the text will still be shown.

TODO: Documentation